### PR TITLE
Update TSHT.VHat to avoid numerical instability

### DIFF
--- a/TSHT.R
+++ b/TSHT.R
@@ -187,6 +187,7 @@ TSHT.VHat <- function(ITT_Y,ITT_D,WUMat,SigmaSqY,SigmaSqD,SigmaYD,tuning = 2.01)
     sigmasq.j = SigmaSqY + beta.j^2 * SigmaSqD - 2* beta.j * SigmaYD
     PHat.bool.j = abs(pi.j) <= sqrt(sigmasq.j * colSums( (WUMat - outer(WUMat[,j]/ITT_D[j], ITT_D))^2)/n) * 
                           sqrt(tuning^2 * log(pz)/n)
+    PHat.bool.j[j] = TRUE  # instrument is always consistent with itself
     VHat.bool.j = PHat.bool.j * SHat.bool
     VHats.bool[as.character(SHat),as.character(j)] = VHat.bool.j[SHat]
   }


### PR DESCRIPTION
Thank you for providing these functions. I got interested in the 'voting matrices' computed by TSHT.VHat and in the process
I discovered a small flaw in the implementation.

When testing consistency of the instrument j with itself, both mean and variance of the test statistic are zero.
Due to numerical errors in computation of the mean, the hypothesis is sometimes rejected, which takes away one vote from the instrument j.

You can see this problem using the basic example from README and adding
`stopifnot(PHat.bool.j[j] == TRUE)` right before my proposed change.
For some seeds this will trigger an error.